### PR TITLE
Add ID attribute to each script to be able to share hashed URLs

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -5,7 +5,7 @@
 </p>
 
 <% @scripts.each do |script| %>
-  <div class="script">
+  <div class="script" id="<%= h script['name'] %>">
     <div class="header">
       <h2>
         <a href="https://github.com/github/hubot-scripts/blob/master/src/scripts/<%=h script['name'] %>" class="name">


### PR DESCRIPTION
Used script's name as an HTML ID.

Example:

http://heroku-script-catalog.herokuapp.com/#walkie.coffee takes me directly to that script.
